### PR TITLE
Add tests for nested quotation marks

### DIFF
--- a/test/test-parse-basic.js
+++ b/test/test-parse-basic.js
@@ -3,7 +3,7 @@
 const yj = require('../index');
 const tap = require('tap');
 
-const str = '{"name":"Ila Gould","age":22,"gender":"female"}';
+const str = '{"name":"Ila Gould","age":22,"gender":"female","nested":"\\"value\\""}';
 
 // Make sure the API works well without the optional parameters.
 yj.parseAsync(str, (err, obj) => {

--- a/test/test-stringify-basic.js
+++ b/test/test-stringify-basic.js
@@ -7,12 +7,16 @@ const obj = {
   name: 'Jacqueline Poole',
   gender: 'female',
   age: 40,
+  a: '"b"',
 };
 
 // Make sure the API works well without optional parameters
 yj.stringifyAsync(obj, (err, str) => {
   if (!err)
-    tap.equal('{"name":"Jacqueline Poole","gender":"female","age":40}', str);
+    tap.equal(
+      '{"name":"Jacqueline Poole","gender":"female","age":40,"a":"\\"b\\""}',
+      str
+    );
   else
     tap.fail(err);
 });


### PR DESCRIPTION
As outlined in #7, the following yields invalid JSON:
```js
yj.stringifyAsync({
  a: 'a',
  b: '"b"',
})

// Result: {"a":"a","b":""b""}
// Expected: {"a":"a","b":"\"b\""}
```

This PR introduces some basic tests to reproduce the issue.