### PR TITLE
src: handle nested quotation marks

### DIFF
--- a/test/test-parse-nestedquotes.js
+++ b/test/test-parse-nestedquotes.js
@@ -1,0 +1,23 @@
+'use strict';
+  
+const yj = require('../index');
+const tap = require('tap');
+
+//string with nested quotes
+const str = '{"name":"Ila Gould","age":22,"gender":"female","nested":"\\"check\\""}';
+
+yj.parseAsync(str, (error, obj) => {
+  if (!error){
+    tap.equal(str,JSON.stringify(obj));
+    yj.stringifyAsync(obj,(err,data) => {
+      if(!err){
+        tap.equal(data,str);
+      }
+      else
+        tap.fail(err);
+     })
+  }
+  else
+    tap.fail(error);
+});
+

--- a/test/test-stringify-nestedquotes.js
+++ b/test/test-stringify-nestedquotes.js
@@ -1,0 +1,28 @@
+'use strict';
+  
+const yj = require('../index');
+const tap = require('tap');
+
+//Object with nested quotes
+const obj = {
+  name: 'Jacqueline Poole',
+  gender: 'female',
+  age: 40,
+  a:"\"b\""
+};
+
+yj.stringifyAsync(obj, (err, str) => {
+  if (!err){
+    tap.equal(JSON.stringify(obj), str);
+    yj.parseAsync(str,(error,data) => {
+      if(!error){
+        tap.deepEquals(data,obj);
+      }
+      else
+        tap.fail(error);
+})
+  }
+  else
+    tap.fail(err);
+});
+

--- a/yieldable-stringify.js
+++ b/yieldable-stringify.js
@@ -42,6 +42,10 @@ let normalize = (string, flagN) => {
   '/[\\\'\u0000-\u001f\u007f-\u009f\u00ad\u0600-\u0604\u070f\u17b4' +
   '\u17b5\u200c-\u200f\u2028-\u202f\u2060-\u206f\ufeff\ufff0-\uffff]/g';
   let unicode = new RegExp(uc);
+  // Taking '\\' out of the loop to avoid change in
+  // order of execution of object entries resulting
+  // in unwanted side effect
+  string = string.replace(/\\/gi, '\\\\');
   let escape = {
     '\b': '\\b',
     '\t': '\\t',
@@ -49,17 +53,17 @@ let normalize = (string, flagN) => {
     '\f': '\\f',
     '\r': '\\r',
     '"': '\\"',
-    '\\': '\\\\',
   };
+  // Escape is implemented globally
+  for(var pattern in escape) {
+    var regex = new RegExp(pattern,'gi')
+    string = string.replace(regex, escape[pattern])
+  }
   unicode.lastIndex = 0;
   if (unicode.test(string)) {
     // Unicode logic here
     transform = string.replace(unicode, (a) => {
-      let c = escape[a];
-      if (typeof c === 'string')
-        return c;
-      else
-        return '\\u' + ('0000' + a.charCodeAt(0).toString(16)).slice(-4);
+      return '\\u' + ('0000' + a.charCodeAt(0).toString(16)).slice(-4);
     });
     if (flagN === 1) {
       transform += temp;


### PR DESCRIPTION
Both APIs fail when the key or value contain quotes. Fix that
by generically applying escape sequencing for all strings that
come as input.

Add two unit tests to validate this scenario.

Refs: https://github.com/ibmruntimes/yieldable-json/pull/6