### PR TITLE
src: descope global variables

### DIFF
--- a/test/test_nested_parse.js
+++ b/test/test_nested_parse.js
@@ -1,0 +1,19 @@
+const yj = require('../index.js');
+const tap = require('tap');
+const obj = '{"obj":{"child":{}}}'
+yj.parseAsync(obj,(err,res) => {
+ if(!err) {
+   tap.equal(obj, JSON.stringify(res));
+ } 
+ else {
+   tap.fail(err);
+ }
+ yj.parseAsync(obj,(err,res) => {
+   if(!err) {
+     tap.equal(obj, JSON.stringify(res));
+   }
+   else {
+     tap.fail(err); 
+   }
+ })
+})

--- a/test/test_nested_stringify.js
+++ b/test/test_nested_stringify.js
@@ -1,0 +1,22 @@
+const yj = require('../index.js')
+const tap = require('tap')
+
+const child = {}
+const obj = {child}
+
+yj.stringifyAsync({obj}, (err, res) => {
+  if(!err) {
+    tap.equal(JSON.stringify({obj}), res)
+  }
+  else {
+    tap.fail(err)
+  }
+  yj.stringifyAsync({obj}, (err, res) => {
+    if(!err) {
+      tap.equal(JSON.stringify({obj}), res)
+    }
+    else {
+      tap.fail(err)
+    }
+  })
+})

--- a/yieldable-stringify.js
+++ b/yieldable-stringify.js
@@ -16,12 +16,7 @@
 
 let counter = 0;
 let objStack = [];
-let flag = 0;
-let flag1 = 0;
 let temp = '';
-let returnStr = '';
-let subStr = '';
-let len = 0;
 const limit = 100000;
 
 function StringifyError(m) {
@@ -108,6 +103,12 @@ function * stringifyYield(field, container, replacer, space, intensity) {
   let tempVal = '';
   let result = '';
   let value = container[field];
+  // Made scope local handling async issues
+  let flag = 0;
+  let flag1 = 0;
+  let returnStr = '';
+  let subStr = '';
+  let len = 0;
 
   // Yield the stringification at definite intervals
   if (++counter > 512 * intensity) {
@@ -269,6 +270,10 @@ let stringifyWrapper = (value, replacer, space, intensity, callback) => {
     setImmediate(() => {
       g = rs.next();
       if (g && g.done === true) {
+        // Reinitializing the values at the end of API call
+        counter = 0;
+        temp = ''
+        objStack = [];
         if (typeof yielding === 'object')
           return callback(yielding, null);
         else


### PR DESCRIPTION
Several variables kept global were causing APIs to fail
when reentered the scope of variables are
shared between each invocation is global. Fix that
by making the scope of those variables local.
    
Add two unit tests to validate this scenario

Refs: #8