### PR TITLE
lib: remove visited objects from stack

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yieldable-json",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "main": "index.js",
   "description": "An asynchronous yieldable version of JSON.stringify and JSON.parse",
   "author": "Gireesh Punathil <gpunathi@in.ibm.com>",

--- a/test/test-stringify-same-object-twice.js
+++ b/test/test-stringify-same-object-twice.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const yj = require('../index');
+const tap = require('tap');
+
+const obj = {
+  name: 'Jacqueline Poole',
+  gender: 'female',
+  age: 40,
+};
+
+const master  = {arr: [ { a: obj }, { b: obj} ] };
+
+// Make sure presence of obj twice in the master
+// object does not cause revisit issues while
+// stringifying it - such as circular dependency
+
+yj.stringifyAsync(obj, (err, str) => {
+  if (!err) {
+    tap.ok(true, 'Repeated object presence cause no issues');
+  } else
+    tap.fail(err);
+});

--- a/yieldable-stringify.js
+++ b/yieldable-stringify.js
@@ -224,7 +224,9 @@ function * stringifyYield(field, container, replacer, space, intensity) {
               ? ': '
               : ':') + val);
           }
+          objStack = objStack.filter((v, i, a) => { return v !== value[key] });
         }
+        objStack = objStack.filter((v, i, a) => { return v !== value });
       }
       return getResult(true);
     default:


### PR DESCRIPTION
Adding visited objects in the stack was helpful in detecting circular references. However, the objects which were processed were never removed. This causes unexpected issues in stringification.

Fixes: https://github.com/ibmruntimes/yieldable-json/issues/24

/cc @HarshithaKP @yathamravali @PoojaDurgad