### PR TITLE
src: handle vertical tab escaping

### DIFF
--- a/test/test-parse-verticaltab.js
+++ b/test/test-parse-verticaltab.js
@@ -1,0 +1,22 @@
+'use strict';
+
+const yj = require('../index');
+const tap = require('tap');
+
+//string with nested quotes
+const str = '{"name":"Ila Gould","age":22,"gender":"female","nested":"\\u000bcheck"}';
+
+yj.parseAsync(str, (error, obj) => {
+  if (!error){
+    tap.equal(str,JSON.stringify(obj));
+    yj.stringifyAsync(obj,(err,data) => {
+      if(!err){
+        tap.equal(data,str);
+      }
+      else
+        tap.fail(err);
+     })
+  }
+  else
+    tap.fail(error);
+});

--- a/test/test-stringify-verticaltab.js
+++ b/test/test-stringify-verticaltab.js
@@ -1,0 +1,27 @@
+'use strict';
+
+const yj = require('../index');
+const tap = require('tap');
+
+//Object with nested quotes
+const obj = {
+  name: 'Jacqueline Poole',
+  gender: 'female',
+  age: 40,
+  a:"\vb"
+};
+
+yj.stringifyAsync(obj, (err, str) => {
+  if (!err){
+    tap.equal(JSON.stringify(obj), str);
+    yj.parseAsync(str,(error,data) => {
+      if(!error){
+        tap.same(data,obj);
+      }
+      else
+        tap.fail(error);
+})
+  }
+  else
+    tap.fail(err);
+});

--- a/yieldable-stringify.js
+++ b/yieldable-stringify.js
@@ -47,6 +47,7 @@ let normalize = (string, flagN) => {
     '\n': '\\n',
     '\f': '\\f',
     '\r': '\\r',
+    '\v': '\\u000b',
     '"': '\\"',
   };
   // Escape is implemented globally


### PR DESCRIPTION
Both APIs fail when the key or value contain vertical tab. Fix that
by adding escape sequencing for vertical tab

Add two unit tests to validate this scenario.
Fixes: #31