### PR TITLE
stringify: fix ASCII control character escapes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules
+.tap
+.nyc_output

--- a/test/test-control-chars.js
+++ b/test/test-control-chars.js
@@ -1,0 +1,68 @@
+'use strict';
+
+// Behavior probe for ASCII control characters U+0000..U+001F.
+// Compares yieldable-json output against the built-in JSON for both
+// stringify and parse, and drills down per code point.
+
+const tap = require('tap');
+const yj = require('../');
+
+function stringifyAsync(value) {
+  return new Promise((resolve, reject) => {
+    yj.stringifyAsync(value, (err, data) => {
+      if (err) reject(err);
+      else resolve(data);
+    });
+  });
+}
+
+function parseAsync(text) {
+  return new Promise((resolve, reject) => {
+    yj.parseAsync(text, (err, data) => {
+      if (err) reject(err);
+      else resolve(data);
+    });
+  });
+}
+
+function allControlChars() {
+  let s = '';
+  for (let i = 0x00; i <= 0x1f; i++) s += String.fromCharCode(i);
+  return s;
+}
+
+function hex(i) {
+  return '0x' + i.toString(16).padStart(2, '0');
+}
+
+tap.test('stringify: string containing every control char 0x00-0x1F', async (t) => {
+  const input = { ctrl: allControlChars() };
+  const expected = JSON.stringify(input);
+  const actual = await stringifyAsync(input);
+  t.equal(actual, expected, 'matches built-in JSON.stringify');
+});
+
+tap.test('parse: round-trip of every control char 0x00-0x1F', async (t) => {
+  const original = { ctrl: allControlChars() };
+  const encoded = JSON.stringify(original);
+  const decoded = await parseAsync(encoded);
+  t.same(decoded, original, 'round-trip preserves all control characters');
+});
+
+tap.test('stringify: per-code-point behavior 0x00-0x1F', async (t) => {
+  for (let i = 0x00; i <= 0x1f; i++) {
+    const obj = { v: String.fromCharCode(i) };
+    const expected = JSON.stringify(obj);
+    const actual = await stringifyAsync(obj);
+    t.equal(actual, expected, `stringify ${hex(i)}`);
+  }
+});
+
+tap.test('parse: per-code-point round-trip 0x00-0x1F', async (t) => {
+  for (let i = 0x00; i <= 0x1f; i++) {
+    const obj = { v: String.fromCharCode(i) };
+    const encoded = JSON.stringify(obj);
+    const decoded = await parseAsync(encoded);
+    t.same(decoded, obj, `parse ${hex(i)}`);
+  }
+});

--- a/yieldable-stringify.js
+++ b/yieldable-stringify.js
@@ -33,10 +33,10 @@ function StringifyError(m) {
 let normalize = (string, flagN) => {
   let retStr = '';
   let transform = '';
-  let uc =
-  '/[\\\'\u0000-\u001f\u007f-\u009f\u00ad\u0600-\u0604\u070f\u17b4' +
-  '\u17b5\u200c-\u200f\u2028-\u202f\u2060-\u206f\ufeff\ufff0-\uffff]/g';
-  let unicode = new RegExp(uc);
+  // Escape remaining ASCII control characters U+0000..U+001F as \u00XX.
+  // The five short-form escapes (\b \t \n \f \r) and the quote are
+  // already handled by the escape table below.
+  let unicode = /[\u0000-\u001f]/g;
   // Taking '\\' out of the loop to avoid change in
   // order of execution of object entries resulting
   // in unwanted side effect


### PR DESCRIPTION
Fixes #56.

## Summary

`stringifyAsync` was emitting ASCII control characters (U+0000 through U+001F) verbatim, except for the five short-form escapes (backspace, tab, line feed, form feed, carriage return). The output was not valid JSON per RFC 8259 and could not be round-tripped through the built-in `JSON.parse`.

The root cause is in `normalize()` in `yieldable-stringify.js`: the escape regex is constructed via `new RegExp(str)` from a string that is shaped like a regex literal (with wrapping slashes and a trailing `g`). The `RegExp` constructor treats those slashes and the `g` as part of the pattern, not as regex-literal syntax, so the resulting regex never matches the intended character class. The escape path was effectively dead code for every control character other than the five handled by the short-form escape table.

## Fix

Replace the broken construction with an actual regex literal covering the range required by RFC 8259 (U+0000 through U+001F). The five short-form escapes and the quote are still handled by the preceding escape table, so the new regex only needs to cover the remaining control characters.

## Test

Adds `test/test-control-chars.js`, which probes every code point in the U+0000..U+001F range for both stringify and parse and compares against the built-in `JSON`. All 66 cases pass after the fix.
